### PR TITLE
Lxnked dev

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -170,6 +170,7 @@ class AnnotationEditorLayer {
       { offsetX: 0, offsetY: 0 },
       /* isCentered = */ false
     );
+    
     editor.setInBackground();
   }
 
@@ -382,6 +383,24 @@ class AnnotationEditorLayer {
     this.#uiManager.addToAnnotationStorage(editor);
   }
 
+  silentAdd(editor) {
+    this.changeParent(editor);
+    this.#uiManager.addEditor(editor);
+    this.attach(editor);
+
+    if (!editor.isAttachedToDOM) {
+      const div = editor.silentRender();
+      this.div.append(div);
+      editor.isAttachedToDOM = true;
+    }
+
+    this.moveEditorInDOM(editor);
+    editor.onceAdded();
+    editor.silentCommit(); 
+    // editor.enableEditMode.bind(editor.)
+    this.#uiManager.addToAnnotationStorage(editor);
+  }
+
   moveEditorInDOM(editor) {
     if (!editor.isAttachedToDOM) {
       return;
@@ -529,6 +548,39 @@ class AnnotationEditorLayer {
     );
   }
 
+
+  createStealthTextEditor(lxnk_id, x, y, text){
+    // const lxnk_id = id; 
+    const id = this.getNextId(); 
+    const editor = new FreeTextEditor({
+      parent: this,
+      id,
+      x: x,
+      y: y,
+      uiManager: this.#uiManager,
+    });
+
+    editor.lxnkSetText(text);
+    // editor.enterInEditMode();
+
+    // Object.defineProperty(
+    //   editor,
+    //   lxnk_id, 
+    //   {
+    //   enumerable: false,
+    //   configurable: false,
+    //   writable: false,
+    //   value: lxnk_id,
+    //   }
+    // )
+
+    // editor.commitOrRemove(); 
+    this.silentAdd(editor);
+
+    return editor; 
+
+  }
+
   /**
    * Set the last selected editor.
    * @param {AnnotationEditor} editor
@@ -596,6 +648,7 @@ class AnnotationEditorLayer {
     }
 
     this.#createAndAddNewEditor(event, /* isCentered = */ false);
+  
   }
 
   /**

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -756,6 +756,37 @@ class AnnotationEditor {
     return this.div;
   }
 
+
+   /**
+   * Render this editor (triggering a minimal number of events) in a div.
+   * @returns {HTMLDivElement}
+   */
+  silentRender() {
+    this.div = document.createElement("div");
+    this.div.setAttribute("data-editor-rotation", (360 - this.rotation) % 360);
+    this.div.className = this.name;
+    this.div.setAttribute("id", this.id);
+    this.div.setAttribute("tabIndex", 0);
+
+    this.setInForeground();
+
+    const [parentWidth, parentHeight] = this.parentDimensions;
+    if (this.parentRotation % 180 !== 0) {
+      this.div.style.maxWidth = `${((100 * parentHeight) / parentWidth).toFixed(
+        2
+      )}%`;
+      this.div.style.maxHeight = `${(
+        (100 * parentWidth) /
+        parentHeight
+      ).toFixed(2)}%`;
+    }
+
+    const [tx, ty] = this.getInitialTranslation();
+    this.translate(tx, ty);
+
+    return this.div;
+  }
+
   /**
    * Onpointerdown callback.
    * @param {PointerEvent} event


### PR DESCRIPTION
This PR adds functionality that allows free text annotations to be created (and rendered) programmatically by a client, without triggering UI events. To enable this, the following changes have been made:

- A `silentRender` method was added to the `FreeTextEditor` class ( in `freetext.js`) and the AnnotationEditor class it inherits from (in `editor.js`). A `silentCommit` method was added to FreeTextEditor as well. `silentRender` and `silentCommit` are versions of the pre-existing `render` and `commit` methods that primarily exclude the LOC that would normally trigger events. 
- `lxnkSetText` and `lxnkSetContent` methods were added to the `FreeTextEditor` class to ease the process of programmatically setting the text content of a `FreeTextEditor` instance.
- A `SilentAdd` method was added to `AnnotationEditorLayer` (in `annotation_editor_layer.js`). `silentAdd` is a version of the pre-existing `add` method that avoids triggering events.
- A `createStealthTextEditor` method was added to `AnnotationEditorLayer`.  `createStealthTextEditor` accepts four arguments: `lxnk_id, x, y, text`. `x` and `y` are the co-ordinates at which the FreeTextEditor should be created, `text` is the intended content of the editor, and 'lxnk_id' is supposed to uniquely identify Annotations created by the Lxnked Editor. 
